### PR TITLE
Remove base64 padding to resolve un-authorization

### DIFF
--- a/src/main/java/com/initializerr/api/k8s/config/aws/EKSClientBuilder.java
+++ b/src/main/java/com/initializerr/api/k8s/config/aws/EKSClientBuilder.java
@@ -28,6 +28,7 @@ public class EKSClientBuilder {
     static Logger logger = LoggerFactory.getLogger(EKSConfig.class);
 
     static ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
+    private static String BASE64_PADDING = "=";
 
     static class Entry {
         WeakReference<DefaultKubernetesClient> clientRef;
@@ -136,6 +137,9 @@ public class EKSClientBuilder {
                 throw new RuntimeException(e);
             }
         });
-        return "k8s-aws-v1." + BaseEncoding.base64Url().encode(sb.toString().getBytes());
+        String encodedUrlWithoutPadding = BaseEncoding.base64Url()
+                .encode(sb.toString().getBytes())
+                .replaceAll(BASE64_PADDING, "");
+        return "k8s-aws-v1." + encodedUrlWithoutPadding;
     }
 }


### PR DESCRIPTION
**Background**
If the encoded URL has padding ( = ), it fails to authentication. Because EKS authenticator does not know this token is whether valid or not. This mechanism is in [aws-cli eks get-token logic code](https://github.com/aws/aws-cli/blob/develop/awscli/customizations/eks/get_token.py#L98).

EKS authenticator logs like below:
> time="2020-05-16T10:44:50Z" level=warning msg="access denied" client="127.0.0.1:36082" error="input token was not properly formatted: illegal base64 data at input byte 991" method=POST path=/authenticate

**Feature**
- remove base64 padding to resolve un-authorization
